### PR TITLE
Harden the GitHub Actions pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: /molecule/docker
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
 
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read  # for actions/checkout to fetch code
       checks: write   # for reviewdog github-pr-check reporter to report findings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ name: CI
     - cron: "42 1 1 * *"
   workflow_dispatch:
 
+permissions: {}
+
 defaults:
   run:
     working-directory: 'ganto.gentoo_portage'
@@ -18,6 +20,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Check out the codebase.
@@ -50,6 +54,8 @@ jobs:
   molecule:
     name: Molecule
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: 'ganto.gentoo_portage'
+          persist-credentials: false
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -62,6 +63,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: 'ganto.gentoo_portage'
+          persist-credentials: false
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           path: 'ganto.gentoo_portage'
           persist-credentials: false
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
 
@@ -60,13 +60,13 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           path: 'ganto.gentoo_portage'
           persist-credentials: false
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ name: CI
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: 'ganto.gentoo_portage'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Add checkout to Ansible role path.
         run: |
           mkdir -p ~/.ansible/roles
-          ln -s $(pwd) ~/.ansible/roles/
+          ln -s "$(pwd)" ~/.ansible/roles/
         shell: bash
 
       - name: Lint code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,19 @@ jobs:
           yamllint .
           ansible-lint .
 
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      checks: write   # for reviewdog github-pr-check reporter to report findings
+    steps:
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1
+
   molecule:
     name: Molecule
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -55,6 +56,7 @@ jobs:
   molecule:
     name: Molecule
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
 

--- a/molecule/podman/molecule.yml
+++ b/molecule/podman/molecule.yml
@@ -12,7 +12,6 @@ platforms:
   - name: instance
     image: "docker.io/gentoo/stage3:latest"
     pre_build_image: True
-    cgroupns_mode: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
 provisioner:


### PR DESCRIPTION
Security review of the CI workflow, focused on least privilege and immutable action references.

## Least privilege

The repository default for workflow permissions is `write`, so every job received a `GITHUB_TOKEN` able to push commits, publish releases and edit issues. Nothing in this pipeline needs that.

- A deny-all `permissions: {}` at workflow level, so any job added later starts with no access and has to opt in.
- `contents: read` for the jobs that only check out code; the actionlint job additionally needs `checks: write` for the reviewdog reporter.
- `persist-credentials: false` on every checkout. Otherwise the token is written into `.git/config`, where the third-party code these jobs run afterwards (`pip install`, `ansible-galaxy install`, `molecule test`) could read it back out. No job pushes anything.

Worth tightening Settings -> Actions -> General -> Workflow permissions to "Read repository contents" as well, so the safe default also applies to workflows that forget a `permissions:` block.

## Immutable action references

Tags are mutable: anyone able to move an upstream `v6` tag would get their code executed here on the next run. All actions are now pinned to a commit SHA with the version kept as a trailing comment. Dependabot understands SHA pins and rewrites both the SHA and the comment, so this does not add maintenance.

## Resource limits

- `timeout-minutes` per job, instead of inheriting the 6 hour default.
- A concurrency group cancelling superseded runs of the same ref.

## Coverage

- Dependabot now watches the Molecule Python requirements, not just the actions.
- A new actionlint job checks the workflow files themselves.